### PR TITLE
velero: Increase cpu limit to 2

### DIFF
--- a/platform/velero/values.yaml
+++ b/platform/velero/values.yaml
@@ -4,6 +4,7 @@ velero:
       cpu: 200m
       memory: 500Mi
     limits:
+      cpu: "2"
       memory: 2Gi
 
   initContainers:


### PR DESCRIPTION
By default it takes 1 as CPU limit