### PR TITLE
metal: Blacklist NVIDIA packages from unattended-upgrades

### DIFF
--- a/metal/roles/prepare/files/50unattended-upgrades
+++ b/metal/roles/prepare/files/50unattended-upgrades
@@ -10,14 +10,13 @@ Unattended-Upgrade::Allowed-Origins {
 };
 
 Unattended-Upgrade::Package-Blacklist {
-    // The following matches all packages starting with linux-
-    // Use $ to explicitely define the end of a package name. Without
-    // the $, "libc6" would match all of them.
-    // Special characters need escaping
-    // The following matches packages like xen-system-amd64, xen-utils-4.1,
-    // xenstore-utils and libxenstore3.0
-    // For more information about Python regular expressions, see
-    // https://docs.python.org/3/howto/regex.html
+    // NVIDIA packages must be managed by the GPU Operator only.
+    // Unattended upgrades of host NVIDIA drivers cause driver/library
+    // version mismatches when the operator manages containerized drivers.
+    "nvidia-.*";
+    "libnvidia-.*";
+    "cuda-.*";
+    "xserver-xorg-video-nvidia-.*";
 };
 
 Unattended-Upgrade::Automatic-Reboot "false";


### PR DESCRIPTION
## Problem

Unattended-upgrades was automatically upgrading NVIDIA host packages (`nvidia-headless-*`, `libnvidia-*`, `cuda-*`, etc.) on GPU nodes. This conflicts with the GPU Operator, which manages NVIDIA drivers as containers. When the host library gets upgraded but the kernel modules are still from the old version (or vice versa), the device plugin crashes with:

```
Driver/library version mismatch — failed to initialize NVML
```

This caused 269 restarts of the `nvidia-device-plugin` on `prusik` before a node reboot realigned the versions.

## Fix

Add NVIDIA package patterns to the unattended-upgrades blacklist in `50unattended-upgrades`:

- `nvidia-.*`
- `libnvidia-.*`
- `cuda-.*`
- `xserver-xorg-video-nvidia-.*`

NVIDIA driver upgrades should only happen through the GPU Operator upgrade controller.

## Post-merge

Re-run the Ansible prepare role on GPU nodes to deploy the updated config:

```bash
cd metal && ANSIBLE_EXTRA_ARGS="-t unattended-upgrades" make cluster
```