### PR TITLE
hermes: increase PVC size to 100Gi

### DIFF
--- a/apps/hermes/templates/pvc.yaml
+++ b/apps/hermes/templates/pvc.yaml
@@ -14,4 +14,4 @@ spec:
     - ReadWriteOnce
   resources:
     requests:
-      storage: 5Gi
+      storage: 100Gi


### PR DESCRIPTION
Increase Hermes data PVC from 5Gi to 100Gi for additional storage capacity.