### PR TITLE
bootstrap: add kiais gitops source and tea.millaguie.net repo creds

### DIFF
--- a/bootstrap/argocd/kustomization.yaml
+++ b/bootstrap/argocd/kustomization.yaml
@@ -3,6 +3,7 @@ kind: Kustomization
 resources:
   - resources/argocd-secrets.yaml
   - resources/external-secret-oci-helm-workaround.yaml
+  - resources/external-secret-oci-helm-workaround-tea.yaml
   - resources/ingress-external.yaml
   - resources/k8s-secret-store/rbac.yaml
   - resources/k8s-secret-store/secret-store.yaml

--- a/bootstrap/argocd/resources/external-secret-oci-helm-workaround-tea.yaml
+++ b/bootstrap/argocd/resources/external-secret-oci-helm-workaround-tea.yaml
@@ -1,0 +1,34 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: argocd-repo-creds-helm-tea-millaguie-net-workaround
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault
+  target:
+    name: argocd-repo-creds-helm-tea-millaguie-net-workaround
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: repository
+      data:
+        config.json: |
+            {
+                "auths": {
+                    "tea.millaguie.net": {
+                        "auth": "{{ printf "%s:%s" .username .password | b64enc }}"
+                    }
+                }
+            }
+
+  data:
+    - secretKey: username
+      remoteRef:
+        key: /argocd/helm-tea-millaguie-net
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: /argocd/helm-tea-millaguie-net
+        property: password

--- a/bootstrap/root/templates/external-secret-helm-tea-millaguie.yaml
+++ b/bootstrap/root/templates/external-secret-helm-tea-millaguie.yaml
@@ -1,0 +1,31 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: argocd-repo-creds-helm-tea-millaguie-net
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault
+  target:
+    name: argocd-repo-creds-helm-tea-millaguie-net
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: repository
+      data:
+        url: tea.millaguie.net
+        type: helm
+        enableOCI: "true"
+        username: {{`"{{ .username }}"`}}
+        password: {{`"{{ .password }}"`}}
+
+  data:
+    - secretKey: username
+      remoteRef:
+        key: /argocd/helm-tea-millaguie-net
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: /argocd/helm-tea-millaguie-net
+        property: password

--- a/bootstrap/root/templates/external-secret-tea-millaguie.yaml
+++ b/bootstrap/root/templates/external-secret-tea-millaguie.yaml
@@ -1,0 +1,30 @@
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+metadata:
+  name: argocd-repo-creds-tea-millaguie-net
+spec:
+  secretStoreRef:
+    kind: ClusterSecretStore
+    name: vault
+  target:
+    name: argocd-repo-creds-tea-millaguie-net
+    template:
+      engineVersion: v2
+      metadata:
+        labels:
+          argocd.argoproj.io/secret-type: repo-creds
+      data:
+        type: git
+        url: https://tea.millaguie.net/
+        username: {{`"{{ .username }}"`}}
+        password: {{`"{{ .password }}"`}}
+
+  data:
+    - secretKey: username
+      remoteRef:
+        key: /argocd/tea-millaguie-net
+        property: username
+    - secretKey: password
+      remoteRef:
+        key: /argocd/tea-millaguie-net
+        property: password

--- a/bootstrap/root/templates/stack-kiais.yaml
+++ b/bootstrap/root/templates/stack-kiais.yaml
@@ -1,0 +1,44 @@
+{{- range $index, $stack := .Values.kiais.stacks }}
+---
+apiVersion: argoproj.io/v1alpha1
+kind: ApplicationSet
+metadata:
+  name: kiais-{{ $stack.name }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+  generators:
+    - git:
+        repoURL: {{ $.Values.kiais.gitops.repo }}
+        revision: {{ $.Values.kiais.gitops.revision }}
+        directories:
+          - path: grigri.cloud/{{ $stack.name }}/*
+  template:
+    metadata:
+      name: '{{ `{{path.basename}}` }}'
+    spec:
+      destination:
+        name: in-cluster
+        namespace: '{{ default `{{path.basename}}` $stack.namespace }}'
+      project: default
+      {{- if $stack.ignoreDifferences }}
+      ignoreDifferences:
+        {{- toYaml $stack.ignoreDifferences | nindent 8 }}
+      {{- end }}
+      source:
+        repoURL: {{ $.Values.kiais.gitops.repo }}
+        path: '{{ `{{path}}` }}'
+        targetRevision: {{ $.Values.kiais.gitops.revision }}
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        retry:
+          limit: 10
+          backoff:
+            duration: 1m
+            factor: 2
+            maxDuration: 16m
+        syncOptions:
+          - CreateNamespace=true
+          - ApplyOutOfSyncOnly=true
+{{- end }}

--- a/bootstrap/root/values.yaml
+++ b/bootstrap/root/values.yaml
@@ -33,3 +33,10 @@ multivara:
   stacks:
     - name: apps
     - name: platform
+
+kiais:
+  gitops:
+    repo: https://tea.millaguie.net/kiais/gitops
+    revision: main
+  stacks:
+    - name: apps


### PR DESCRIPTION
Wire the new kiais/gitops repo (tea.millaguie.net) into the bootstrap, mirroring the multivara pattern:

- root/values.yaml: add kiais gitops source (repo + revision main, stack apps)
- root/templates/stack-kiais.yaml: ApplicationSet kiais-apps scanning grigri.cloud/apps/*
- root/templates/external-secret-tea-millaguie.yaml: git repo-creds for https://tea.millaguie.net/
- root/templates/external-secret-helm-tea-millaguie.yaml: helm OCI repository (tea.millaguie.net)
- argocd/resources/external-secret-oci-helm-workaround-tea.yaml: OCI docker-config workaround (registered in argocd kustomization)

Vault paths: secret/argocd/tea-millaguie-net + secret/argocd/helm-tea-millaguie-net (already populated). Verified via helm template (kiais-apps ApplicationSet renders correctly).